### PR TITLE
Fixed gradle to allow it to be included as external library

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -42,5 +42,5 @@ dokka {
     outputDirectory = "$buildDir/dokka"
 }
 
-apply from: rootProject.file('gradle/maven-android-prepare.gradle')
-apply from: rootProject.file('gradle/maven-publish.gradle')
+apply from: parent.file('gradle/maven-android-prepare.gradle')
+apply from: parent.file('gradle/maven-publish.gradle')


### PR DESCRIPTION
To work on the library locally to suit our needs, I imported the library as external library in the project. When doing so it will try looking for those files in the root (of our) project instead of its actual parent. This will fix that.